### PR TITLE
Fix auth_callback for assignees field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.2.2
+
+- Bug: Fix meta field auth callback to allow saving posts through the REST API.
+  
 v0.2.1
 
 - Bug: Stop workflow comments showing anywhere other than REST API endpoint

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -161,7 +161,7 @@ function assignees_api() {
 		'type'          => 'integer',
 		'description'   => __( 'The assignees user IDs for this post.', 'hm-workflows' ),
 		'single'        => false,
-        'auth_callback' => function ( $allowed, $meta_key, $post_id, $user_id ) {
+		'auth_callback' => function ( $allowed, $meta_key, $post_id, $user_id ) {
 			return user_can( $user_id, 'edit_post', $post_id );
 		},
 		'show_in_rest'  => true,

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -161,7 +161,7 @@ function assignees_api() {
 		'type'          => 'integer',
 		'description'   => __( 'The assignees user IDs for this post.', 'hm-workflows' ),
 		'single'        => false,
-		'auth_callback' => function ( $allowed, $post_id, $user_id ) {
+        'auth_callback' => function ( $allowed, $meta_key, $post_id, $user_id ) {
 			return user_can( $user_id, 'edit_post', $post_id );
 		},
 		'show_in_rest'  => true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",


### PR DESCRIPTION
Allows posts to be saved using the REST API.

See #41. 

- [x] Updated changelog
- [x] Updated `VERSION` file with appropriate MAJOR.MINOR.PATCH change