### PR TITLE
Improve the terminology to distinguish between comment assignees post assignees

### DIFF
--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -10,7 +10,7 @@ use WP_Comment_Query;
 use WP_Query;
 
 Event::register( 'new_editorial_comment' )
-	->add_ui( __( 'A new editorial comment was added', 'hm-workflows' ) )
+	->add_ui( __( 'A new editorial comment is added', 'hm-workflows' ) )
 	->set_listener( [
 		'action'        => 'wp_insert_comment',
 		'callback'      => function ( $id, WP_Comment $comment ) {
@@ -78,7 +78,7 @@ Event::register( 'new_editorial_comment' )
 				return get_user_by( 'id', $user_id );
 			}, (array) get_comment_meta( $comment->comment_ID, 'assignees' ) );
 		},
-		__( 'Assignees', 'hm-workflows' )
+		__( 'Comment assignees', 'hm-workflows' )
 	);
 
 

--- a/lib/recipients/post-assignee.php
+++ b/lib/recipients/post-assignee.php
@@ -23,24 +23,24 @@ function get_post_assignees( $post ) {
 	}, $assignees );
 }
 
-// Add an assignee recipient handler to built in events.
+// Add a post assignee recipient handler to built in events.
 Event::get( 'draft_to_pending' )
 	->add_recipient_handler(
 		'assignee',
 		__NAMESPACE__ . '\get_post_assignees',
-		__( 'Assignees', 'hm-workflows' )
+		__( 'Post Assignees', 'hm-workflows' )
 	);
 
 Event::get( 'publish_post' )
 	->add_recipient_handler(
 		'assignee',
 		__NAMESPACE__ . '\get_post_assignees',
-		__( 'Assignees', 'hm-workflows' )
+		__( 'Post Assignees', 'hm-workflows' )
 	);
 
 Event::get( 'publish_page' )
 	->add_recipient_handler(
 		'assignee',
 		__NAMESPACE__ . '\get_post_assignees',
-		__( 'Assignees', 'hm-workflows' )
+		__( 'Post Assignees', 'hm-workflows' )
 	);


### PR DESCRIPTION
When creating a workflow that deals with editorial comments, it's not clear whether the "Assignees" recipient is the post assignee or the editorial comment assignee. This fixes that.

I haven't updated the package or changelog because I've got some other fixes on the way too.