### PR TITLE
Don't show an "Assigned to me" link on the post listing screen when nothing is assigned to me

### DIFF
--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -246,6 +246,10 @@ function add_assignee_filter_link() {
 				AND pm.meta_value = %s
 			", $post_type, get_current_user_id(), get_current_user_id() ) ) );
 
+			if ( ! $assigned_posts_count ) {
+				return $views;
+			}
+
 			$label = esc_html__( 'Assigned to me', 'hm-workflows' );
 
 			$views['assigned'] = sprintf(


### PR DESCRIPTION
This brings the feature inline with core, which doesn't show filter links for statuses with zero results.