### PR TITLE
Remove unnecessary duplicate includes

### DIFF
--- a/lib/recipients/post-assignee.php
+++ b/lib/recipients/post-assignee.php
@@ -7,9 +7,6 @@
 
 namespace HM\Workflows;
 
-require_once dirname( __DIR__ ) . '/events/transition-post-status.php';
-require_once dirname( __DIR__ ) . '/events/new-editorial-comment.php';
-
 /**
  * Get assigned user IDs for a post.
  *

--- a/lib/recipients/post-author.php
+++ b/lib/recipients/post-author.php
@@ -7,8 +7,6 @@
 
 namespace HM\Workflows;
 
-require_once dirname( __DIR__ ) . '/events/transition-post-status.php';
-
 function get_author( $post ) {
 	return get_user_by( 'id', get_post( $post )->post_author );
 }


### PR DESCRIPTION
AFAICT these are duplicates and unnecessary. The actual includes happen here: https://github.com/humanmade/Workflows/blob/42322a3a994c5534a1aaf47556fa540301244361/plugin.php#L28-L29