### PR TITLE
Register an event for handling new comments

### DIFF
--- a/lib/events/new-comment.php
+++ b/lib/events/new-comment.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Built in event for new comments.
+ */
+
+namespace HM\Workflows;
+
+use WP_Comment;
+
+Event::register( 'published_comment' )
+	->add_ui( __( 'A new comment is published', 'hm-workflows' ) )
+	->set_listener( [
+		'action'        => 'wp_insert_comment',
+		'callback'      => function ( $id, WP_Comment $comment ) {
+			// The default comment type is an empty string. Ignore any other comment types.
+			if ( $comment->comment_type !== '' ) {
+				return null;
+			}
+
+			// Ignore unapproved comments.
+			if ( $comment->comment_approved !== '1' ) {
+				return null;
+			}
+
+			return $comment;
+		},
+		'accepted_args' => 2,
+	] )
+	->add_message_tags( [
+		'comment.author' => function ( WP_Comment $comment ) : string {
+			return $comment->comment_author;
+		},
+		'comment.text'   => function ( WP_Comment $comment ) : string {
+			return $comment->comment_content;
+		},
+		'comment.url'    => function ( WP_Comment $comment ) : string {
+			return get_comment_link( $comment );
+		},
+		'post.title'     => function ( WP_Comment $comment ) : string {
+			return get_the_title( $comment->comment_post_ID );
+		},
+		'post.url'       => function ( WP_Comment $comment ) : string {
+			return get_permalink( $comment->comment_post_ID );
+		},
+	] )
+	->add_message_action(
+		'view',
+		__( 'View comment', 'hm-workflows' ),
+		function ( int $comment_id ) : string {
+			return get_comment_link( $comment_id );
+		},
+		function ( WP_Comment $comment ) : array {
+			return [
+				'comment_id' => $comment->comment_ID,
+			];
+		},
+		[
+			'comment_id' => 'intval',
+		]
+	);

--- a/lib/recipients/post-author.php
+++ b/lib/recipients/post-author.php
@@ -7,13 +7,15 @@
 
 namespace HM\Workflows;
 
+use WP_Comment;
+
 require_once dirname( __DIR__ ) . '/events/transition-post-status.php';
 
 function get_author( $post ) {
 	return get_user_by( 'id', get_post( $post )->post_author );
 }
 
-// Add an assignee recipient handler to built in events.
+// Add an author recipient handler to built in events.
 Event::get( 'draft_to_pending' )
 	->add_recipient_handler(
 		'post_author',
@@ -32,5 +34,21 @@ Event::get( 'publish_page' )
 	->add_recipient_handler(
 		'post_author',
 		__NAMESPACE__ . '\get_author',
+		__( 'Post author', 'hm-workflows' )
+	);
+
+Event::get( 'published_comment' )
+	->add_recipient_handler(
+		'post_author',
+		function( WP_Comment $comment ) {
+			$author = get_author( $comment->comment_post_ID );
+
+			// Don't notify the post author about their own comments:
+			if ( $author->ID === $comment->user_id ) {
+				return null;
+			}
+
+			return $author;
+		},
 		__( 'Post author', 'hm-workflows' )
 	);

--- a/plugin.php
+++ b/plugin.php
@@ -26,6 +26,7 @@ add_action( 'plugins_loaded', function () {
 	require_once __DIR__ . '/lib/destinations/slack.php';
 	require_once __DIR__ . '/lib/destinations/dashboard.php';
 	require_once __DIR__ . '/lib/events/transition-post-status.php';
+	require_once __DIR__ . '/lib/events/new-comment.php';
 	require_once __DIR__ . '/lib/events/new-editorial-comment.php';
 	require_once __DIR__ . '/lib/recipients/post-assignee.php';
 	require_once __DIR__ . '/lib/recipients/post-author.php';


### PR DESCRIPTION
This adds an event for handling the publishing of an approved comment. It also adds a recipient handler for the author of the corresponding post.

Notes:

* Only applies to the default comment type
* Only applies to approved comments
* Doesn't notify the post author if they are the author of the comment