### PR TITLE
Ensure recipient is a string before passing it to `is_email()`

### DIFF
--- a/inc/class-workflow.php
+++ b/inc/class-workflow.php
@@ -273,7 +273,7 @@ class Workflow {
 		// Process recipients.
 		$recipients = [];
 		foreach ( $this->recipients as $recipient ) {
-			if ( is_email( $recipient ) ) {
+			if ( is_string( $recipient ) && is_email( $recipient ) ) {
 				// Get user by email or add plain email.
 				$user = get_user_by( 'email', $recipient );
 				if ( is_a( $user, 'WP_User' ) ) {


### PR DESCRIPTION
My PHP error log is full of the following warnings:

    strlen() expects parameter 1 to be string, object given

This is caused by `$recipient` being passed to `is_email()` without first checking that it's a string. It gets passed through to `strlen()` which triggers this warning whenever the recipient is, for example, a `WP_User` object (which it is most of the time).

This change fixes that.