### PR TITLE
Add some defence for non-existent event types

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -192,6 +192,11 @@ add_action( 'hm.workflows.init', function () {
 
 		// Set Event UI data.
 		$event_object = Event::get( $event['id'] );
+
+		if ( empty( $event_object ) ) {
+			continue;
+		}
+
 		$event_object->get_ui()->set_data( $event['data'] );
 
 		// Map recipients to values or ID.


### PR DESCRIPTION
If a stored workflow references a non-existent event type (for example, a workflow was stored for an event type that no longer exists), it causes a fatal error on every page load:

    Uncaught Error: Call to a member function get_ui() on null in workflows/inc/namespace.php:195

This change avoids that fatal error.