### PR TITLE
Fix assignees api calls with dedicated endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.3.1
+
+- Bug: Fix the editorial comments assignees endpoints.
+
 v0.3.0
 
 - Enhancement: Register an event for handling new comments, and a recipient handler for the author of the corresponding post.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 v0.3.1
 
 - Bug: Fix the editorial comments assignees endpoints.
+- UI: Remove slug div from workflows edit screen
 
 v0.3.0
 

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -18,6 +18,7 @@ add_action( 'edit_form_after_title', __NAMESPACE__ . '\\main_ui' );
 
 function meta_boxes() {
 	remove_meta_box( 'submitdiv', 'hm_workflow', 'side' );
+	remove_meta_box( 'slug', 'hm_workflow', 'normal' );
 
 	add_meta_box( 'enable-workflow', __( 'Workflow options', 'hm-workflows' ), function () {
 		echo '<div id="hm-workflow-options"></div>';

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -18,7 +18,7 @@ add_action( 'edit_form_after_title', __NAMESPACE__ . '\\main_ui' );
 
 function meta_boxes() {
 	remove_meta_box( 'submitdiv', 'hm_workflow', 'side' );
-	remove_meta_box( 'slug', 'hm_workflow', 'normal' );
+	remove_meta_box( 'slugdiv', 'hm_workflow', 'normal' );
 
 	add_meta_box( 'enable-workflow', __( 'Workflow options', 'hm-workflows' ), function () {
 		echo '<div id="hm-workflow-options"></div>';

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -10728,798 +10728,68 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
-        "detect-port-alt": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
-          "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "address": "^1.0.1",
-            "debug": "^2.6.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
-        "fsevents": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-          "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-          "optional": true,
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "requires": {
-            "nan": "^2.3.0",
-            "node-pre-gyp": "^0.6.36"
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "^0.14.3"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "~2.0.0"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.x.x"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "^0.4.1",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.x.x"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "inherits": "2",
-                "minimatch": "^3.0.0"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0"
-              }
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsonify": "~0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.0.2",
-                "json-schema": "0.2.3",
-                "verror": "1.3.6"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true,
-              "requires": {
-                "mime-db": "~1.27.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "npmlog": "^4.0.2",
-                "rc": "^1.1.7",
-                "request": "^2.81.0",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^2.2.1",
-                "tar-pack": "^3.4.0"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "~0.4.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true,
-              "requires": {
-                "buffer-shims": "~1.0.0",
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "hoek": "2.x.x"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jodid25519": "^1.0.0",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "fstream": "^1.0.10",
-                "fstream-ignore": "^1.0.5",
-                "once": "^1.3.3",
-                "readable-stream": "^2.1.4",
-                "rimraf": "^2.5.1",
-                "tar": "^2.2.1",
-                "uid-number": "^0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "extsprintf": "1.0.2"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
+          }
+        },
+        "import-local": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+          "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+          "requires": {
+            "pkg-dir": "^2.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
           }
         },
         "minimist": {
@@ -11527,13 +10797,23 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
-        "opn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-          "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "is-wsl": "^1.1.0"
+            "lcid": "^1.0.0"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "promise": {
           "version": "8.0.1",
@@ -11544,33 +10824,33 @@
           }
         },
         "react-dev-utils": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.1.tgz",
-          "integrity": "sha1-nydj57r6GhucUiVNKked7sKA8RE=",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
+          "integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
           "requires": {
             "address": "1.0.3",
             "babel-code-frame": "6.26.0",
             "chalk": "1.1.3",
             "cross-spawn": "5.1.0",
-            "detect-port-alt": "1.1.3",
+            "detect-port-alt": "1.1.6",
             "escape-string-regexp": "1.0.5",
             "filesize": "3.5.11",
             "global-modules": "1.0.0",
             "gzip-size": "3.0.0",
             "inquirer": "3.3.0",
             "is-root": "1.0.0",
-            "opn": "5.1.0",
-            "react-error-overlay": "^3.0.0",
+            "opn": "5.2.0",
+            "react-error-overlay": "^4.0.1",
             "recursive-readdir": "2.2.1",
             "shell-quote": "1.6.1",
-            "sockjs-client": "1.1.4",
+            "sockjs-client": "1.1.5",
             "strip-ansi": "3.0.1",
             "text-table": "0.2.0"
           },
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
                 "ansi-styles": "^2.2.1",
@@ -11579,32 +10859,46 @@
                 "strip-ansi": "^3.0.0",
                 "supports-color": "^2.0.0"
               }
+            },
+            "sockjs-client": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+              "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+              "requires": {
+                "debug": "^2.6.6",
+                "eventsource": "0.1.6",
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
+              }
             }
           }
         },
         "react-error-overlay": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
-          "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
+          "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw=="
         },
         "react-scripts": {
-          "version": "1.0.17",
-          "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.17.tgz",
-          "integrity": "sha512-tf2kBx230iUSxqJZxboYINlIOKryW+CC7oVgQ4rguNLmcPgWvnnCM8huAgCgL2yuqDd0qQvnI5sRCmc+0TQ5zw==",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.1.5.tgz",
+          "integrity": "sha512-ZXqnbg+kLRaacAkjuedMFTgKu9lNltMDDsuwn37CTV7X2tuZQmDKi08eI3LYvtpjqh5vm8/6BhwHRHkRtvMyJg==",
           "requires": {
             "autoprefixer": "7.1.6",
             "babel-core": "6.26.0",
             "babel-eslint": "7.2.3",
             "babel-jest": "20.0.3",
             "babel-loader": "7.1.2",
-            "babel-preset-react-app": "^3.1.0",
+            "babel-preset-react-app": "^3.1.2",
             "babel-runtime": "6.26.0",
             "case-sensitive-paths-webpack-plugin": "2.1.1",
             "chalk": "1.1.3",
             "css-loader": "0.28.7",
             "dotenv": "4.0.0",
+            "dotenv-expand": "4.2.0",
             "eslint": "4.10.0",
-            "eslint-config-react-app": "^2.0.1",
+            "eslint-config-react-app": "^2.1.0",
             "eslint-loader": "1.9.0",
             "eslint-plugin-flowtype": "2.39.1",
             "eslint-plugin-import": "2.8.0",
@@ -11613,7 +10907,7 @@
             "extract-text-webpack-plugin": "3.0.2",
             "file-loader": "1.1.5",
             "fs-extra": "3.0.1",
-            "fsevents": "1.1.2",
+            "fsevents": "^1.1.3",
             "html-webpack-plugin": "2.29.0",
             "jest": "20.0.4",
             "object-assign": "4.1.1",
@@ -11621,19 +10915,20 @@
             "postcss-loader": "2.0.8",
             "promise": "8.0.1",
             "raf": "3.4.0",
-            "react-dev-utils": "^4.2.1",
+            "react-dev-utils": "^5.0.2",
+            "resolve": "1.6.0",
             "style-loader": "0.19.0",
             "sw-precache-webpack-plugin": "0.11.4",
             "url-loader": "0.6.2",
             "webpack": "3.8.1",
-            "webpack-dev-server": "2.9.4",
+            "webpack-dev-server": "2.11.3",
             "webpack-manifest-plugin": "1.3.2",
             "whatwg-fetch": "2.0.3"
           },
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
                 "ansi-styles": "^2.2.1",
@@ -11642,12 +10937,121 @@
                 "strip-ansi": "^3.0.0",
                 "supports-color": "^2.0.0"
               }
+            },
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "sockjs-client": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+              "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+              "requires": {
+                "debug": "^2.6.6",
+                "eventsource": "0.1.6",
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+              }
+            },
+            "webpack-dev-server": {
+              "version": "2.11.3",
+              "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
+              "integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
+              "requires": {
+                "ansi-html": "0.0.7",
+                "array-includes": "^3.0.3",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.0.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "debug": "^3.1.0",
+                "del": "^3.0.0",
+                "express": "^4.16.2",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.17.4",
+                "import-local": "^1.0.0",
+                "internal-ip": "1.2.0",
+                "ip": "^1.1.5",
+                "killable": "^1.0.0",
+                "loglevel": "^1.4.1",
+                "opn": "^5.1.0",
+                "portfinder": "^1.0.9",
+                "selfsigned": "^1.9.1",
+                "serve-index": "^1.7.2",
+                "sockjs": "0.3.19",
+                "sockjs-client": "1.1.5",
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^5.1.0",
+                "webpack-dev-middleware": "1.12.2",
+                "yargs": "6.6.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
             }
+          }
+        },
+        "sockjs": {
+          "version": "0.3.19",
+          "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+          "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+          "requires": {
+            "faye-websocket": "^0.10.0",
+            "uuid": "^3.0.1"
+          },
+          "dependencies": {
+            "faye-websocket": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+              "requires": {
+                "websocket-driver": ">=0.5.1"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -11662,6 +11066,39 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
           "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
         }
       }
     },

--- a/admin/src/Comments/index.js
+++ b/admin/src/Comments/index.js
@@ -138,7 +138,7 @@ class Comments extends React.Component {
 	}
 
 	fetchAssignees() {
-		fetch( `${HM.Workflows.Endpoints.WP}/posts/${this.props.postId}`, {
+		fetch( `${HM.Workflows.Namespace}/assignees/${this.props.postId}`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': HM.Workflows.Nonce
@@ -146,11 +146,11 @@ class Comments extends React.Component {
 		} )
 			.then( response => response.json() )
 			.then( data => {
-				if ( ! data.meta || Array.isArray( data.meta ) || ! data.meta.assignees ) {
+				if ( ! data || ! Array.isArray( data ) ) {
 					return;
 				}
 
-				const { assignees } = data.meta;
+				const assignees = data;
 				this.setState( { assignees } );
 			} );
 	}
@@ -233,22 +233,20 @@ class Comments extends React.Component {
 	updateAssignees() {
 		const { newAssignees } = this.state;
 
-		fetch( `${HM.Workflows.Endpoints.WP}/posts/${this.props.postId}?context=edit`, {
-			method: 'PATCH',
+		fetch( `${HM.Workflows.Namespace}/assignees/${this.props.postId}`, {
+			method: 'POST',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': HM.Workflows.Nonce,
 				'Content-Type': 'application/json',
 			},
 			body: JSON.stringify( {
-				meta: {
-					assignees: this.state.newAssignees,
-				},
+				assignees: this.state.newAssignees,
 			} ),
 		} )
 			.then( response => response.json() )
 			.then( data => {
-				if ( ! data.meta || Array.isArray( data.meta ) || ! data.meta.assignees ) {
+				if ( ! data || ! Array.isArray( data ) ) {
 					return;
 				}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.0
+ * Version: 0.3.1
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
The endpoint to fetch assignee metadata was hardcoded to `wp/v2/posts`, it's not possible to accurately get the posts controller endpoint for post types in PHP so this was the safest way to ensure support, gutenberg or no.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change