### PR TITLE
84 Replace get_the_title() with raw post_title value in the Events folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.3.5
+
+- Bug: Fix character encoding in titles, should send raw data to destination endpoints
+
 v0.3.4
 
 - Bug: Fix incorrect escaping for dashboard notifications #81

--- a/lib/events/new-comment.php
+++ b/lib/events/new-comment.php
@@ -37,7 +37,7 @@ Event::register( 'published_comment' )
 			return get_comment_link( $comment );
 		},
 		'post.title'     => function ( WP_Comment $comment ) : string {
-			return get_the_title( $comment->comment_post_ID );
+			return get_post( $comment->comment_post_ID )->post_title;
 		},
 		'post.url'       => function ( WP_Comment $comment ) : string {
 			return get_permalink( $comment->comment_post_ID );

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -42,7 +42,7 @@ Event::register( 'new_editorial_comment' )
 			return implode( ', ', $assignees );
 		},
 		'post.title'     => function ( WP_Comment $comment ) {
-			return get_the_title( $comment->comment_post_ID );
+			return get_post( $comment->comment_post_ID )->post_title;
 		},
 		'post.url'       => function ( WP_Comment $comment ) {
 			$post = get_post( $comment->comment_post_ID );

--- a/lib/events/transition-post-status.php
+++ b/lib/events/transition-post-status.php
@@ -8,7 +8,7 @@ namespace HM\Workflows;
 function get_messages_tags() {
 	return [
 		'title'   => function ( $post ) {
-			return get_the_title( get_post( $post )->ID );
+			return get_post( $post )->post_title;
 		},
 		'excerpt' => function ( $post ) {
 			if ( has_excerpt( $post ) ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.4
+ * Version: 0.3.5
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Issue: https://github.com/humanmade/Workflows/issues/84

@roborourke I replaced all `get_the_title()` instances in the `events` folder only to use the post raw title (not put through filters).

Not tested :yolo:, if you could run some tests would be great 👍 

- [ ] Updated changelog
- [ ] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
