### PR TITLE
Remove typehinting on get_recipient_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+v0.3.9
+- Bug: Fix crash with "specific users" recipient #112
+
 v0.3.8
 - Bug add `remove` method for Events #107
 

--- a/inc/class-event.php
+++ b/inc/class-event.php
@@ -268,10 +268,10 @@ class Event {
 	 *
 	 * @param string $id The handler ID.
 	 *
-	 * @return callable
+	 * @return callable|null
 	 */
-	public function get_recipient_handler( string $id ): callable {
-		return $this->recipients_handlers[ $id ]['callback'];
+	public function get_recipient_handler( string $id ) {
+		return $this->recipients_handlers[ $id ]['callback'] ?? null;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.8
+ * Version: 0.3.9
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
get_recipient_handler() can also take a user ID directly, in which case there's no handler set. This defaults the value (to avoid warnings), and removes the typehint to avoid crashing PHP if a non-callable function is returned.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
