### PR TITLE
Fix site admin permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 Changelog
 =========
 
+v0.3.10
+- Bug: Allow site admins access to workflows UI
+
 v0.3.9
 - Bug: Fix crash with "specific users" recipient #112
 
 v0.3.8
-- Bug add `remove` method for Events #107
+- Bug: add `remove` method for Events #107
 
 v0.3.7
 - Bug: add `remove` method for Destinations #100

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,6 +76,10 @@ add_action( 'init', function () {
  */
 add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id ) {
 	switch ( $cap ) {
+		case 'edit_workflow':
+		case 'read_workflow':
+		case 'publish_workflow':
+		case 'delete_workflow':
 		case 'edit_workflows':
 		case 'edit_others_workflows':
 		case 'publish_workflows':

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,10 +76,16 @@ add_action( 'init', function () {
  */
 add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id ) {
 	switch ( $cap ) {
-		case 'edit_workflow':
-		case 'read_workflow':
-		case 'publish_workflow':
-		case 'delete_workflow':
+		case 'edit_workflows':
+		case 'edit_others_workflows':
+		case 'publish_workflows':
+		case 'read_private_workflows':
+		case 'delete_workflows':
+		case 'delete_private_workflows':
+		case 'delete_published_workflows':
+		case 'delete_others_workflows':
+		case 'edit_private_workflows':
+		case 'edit_published_workflows':
 			$caps = array_diff( $caps, [ $cap ] );
 			if ( user_can( $user_id, 'manage_options' ) ) {
 				$caps[] = 'manage_options';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.9
+ * Version: 0.3.10
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
The incorrect (non plural) primitive capabilities were being checked in the map_meta_cap filter so site admins never actually had access.


- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change