### PR TITLE
Fix REST route registration

### DIFF
--- a/inc/class-rest-webhook-controller.php
+++ b/inc/class-rest-webhook-controller.php
@@ -31,9 +31,10 @@ class REST_Webhook_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route( $this->namespace, $this->rest_base . '/(?P<event>[\\w\-\.]+)\/(?P<action>[\\w\-\.]+)', [
-			'methods'  => WP_REST_Server::READABLE,
+			'methods' => WP_REST_Server::READABLE,
 			'callback' => [ $this, 'handle_endpoint_response' ],
-			'args'     => [
+			'permission_callback' => '__return_true',
+			'args' => [
 				'payload'   => [
 					'type'              => 'string',
 					'description'       => __( 'A base64 encoded JSON payload.', 'hm-workflows' ),

--- a/lib/destinations/dashboard.php
+++ b/lib/destinations/dashboard.php
@@ -62,10 +62,10 @@ add_action( 'rest_api_init', function () {
 	];
 
 	register_rest_route( REST_NAMESPACE, 'notifications/(?P<user>[\\d]+)', [
-		'methods'              => WP_REST_Server::READABLE,
-		'callback'             => __NAMESPACE__ . '\get_all',
-		'permissions_callback' => __NAMESPACE__ . '\permissions',
-		'schema'               => [
+		'methods'             => WP_REST_Server::READABLE,
+		'callback'            => __NAMESPACE__ . '\get_all',
+		'permission_callback' => __NAMESPACE__ . '\permissions',
+		'schema'              => [
 			'type'  => 'array',
 			'items' => [
 				'type'       => 'object',
@@ -75,32 +75,32 @@ add_action( 'rest_api_init', function () {
 	] );
 
 	register_rest_route( REST_NAMESPACE, 'notifications/(?P<user>[\\d]+)', [
-		'methods'              => WP_REST_Server::CREATABLE,
-		'callback'             => __NAMESPACE__ . '\create',
-		'permissions_callback' => __NAMESPACE__ . '\permissions',
-		'args'                 => $schema,
-		'schema'               => $schema_with_id,
+		'methods'             => WP_REST_Server::CREATABLE,
+		'callback'            => __NAMESPACE__ . '\create',
+		'permission_callback' => __NAMESPACE__ . '\permissions',
+		'args'                => $schema,
+		'schema'              => $schema_with_id,
 	] );
 
 	register_rest_route( REST_NAMESPACE, 'notifications/(?P<user>[\\d]+)/(?P<id>[\\d]+)', [
-		'methods'              => WP_REST_Server::READABLE,
-		'callback'             => __NAMESPACE__ . '\get_one',
-		'permissions_callback' => __NAMESPACE__ . '\permissions',
-		'schema'               => $schema_with_id,
+		'methods'             => WP_REST_Server::READABLE,
+		'callback'            => __NAMESPACE__ . '\get_one',
+		'permission_callback' => __NAMESPACE__ . '\permissions',
+		'schema'              => $schema_with_id,
 	] );
 
 	register_rest_route( REST_NAMESPACE, 'notifications/(?P<user>[\\d]+)/(?P<id>[\\d]+)', [
-		'methods'              => WP_REST_Server::EDITABLE,
-		'callback'             => __NAMESPACE__ . '\edit',
-		'permissions_callback' => __NAMESPACE__ . '\permissions',
-		'args'                 => $schema,
-		'schema'               => $schema_with_id,
+		'methods'             => WP_REST_Server::EDITABLE,
+		'callback'            => __NAMESPACE__ . '\edit',
+		'permission_callback' => __NAMESPACE__ . '\permissions',
+		'args'                => $schema,
+		'schema'              => $schema_with_id,
 	] );
 
 	register_rest_route( REST_NAMESPACE, 'notifications/(?P<user>[\\d]+)/(?P<id>[\\d]+)', [
-		'methods'              => WP_REST_Server::DELETABLE,
-		'callback'             => __NAMESPACE__ . '\delete',
-		'permissions_callback' => __NAMESPACE__ . '\permissions',
+		'methods'             => WP_REST_Server::DELETABLE,
+		'callback'            => __NAMESPACE__ . '\delete',
+		'permission_callback' => __NAMESPACE__ . '\permissions',
 	] );
 } );
 


### PR DESCRIPTION
Omitting the `permission_callback` parameter is now deprecated and must be explicitly set.


- [ ] Updated changelog
- [ ] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change