### PR TITLE
Ensure publish post/page events only fire once

### DIFF
--- a/lib/events/transition-post-status.php
+++ b/lib/events/transition-post-status.php
@@ -86,6 +86,21 @@ Event::register( 'draft_to_pending' )
 	->add_ui( __( 'A post is pending review', 'hm-workflows' ) );
 
 Event::register( 'publish_post' )
+	->set_listener( [
+		'action'        => 'transition_post_status',
+		'callback'      => function ( $new_status, $old_status, \WP_Post $post ) {
+			if ( $new_status === $old_status ) {
+				return null;
+			}
+
+			if ( $new_status !== 'publish' ) {
+				return null;
+			}
+
+			return [ $post, $old_status, $new_status ];
+		},
+		'accepted_args' => 3,
+	] )
 	->add_message_tags( get_messages_tags() )
 	->add_message_action(
 		'view',
@@ -101,6 +116,21 @@ Event::register( 'publish_post' )
 	->add_ui( __( 'A post is published', 'hm-workflows' ) );
 
 Event::register( 'publish_page' )
+	->set_listener( [
+		'action'        => 'transition_post_status',
+		'callback'      => function ( $new_status, $old_status, \WP_Post $post ) {
+			if ( $new_status === $old_status ) {
+				return null;
+			}
+
+			if ( $new_status !== 'publish' ) {
+				return null;
+			}
+
+			return [ $post, $old_status, $new_status ];
+		},
+		'accepted_args' => 3,
+	] )
 	->add_message_tags( get_messages_tags() )
 	->add_message_action(
 		'view',


### PR DESCRIPTION
Previously these events fired on every update to the content, this properly checks the status transition.


- [ ] Updated changelog
- [ ] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change