### PR TITLE
Fix withFetch caching and reduce notification polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.3.14
+- Bug: Fix cache key in `withFetch` component
+- Enhancement: Reduce polling time for admin notifications
+
 v0.3.13
 - Bug: Avoid error message when submitting editorial comment
 - Enhancement: Rename editorial comments meta box

--- a/admin/src/Notifications/index.js
+++ b/admin/src/Notifications/index.js
@@ -135,7 +135,7 @@ class Notifications extends React.Component {
 const notificationsWithFetch = withFetch(
 	`${HM.Workflows.Namespace}/notifications/${HM.Workflows.User}`,
 	{
-		expires:     10 * 1000,
+		expires:     60000,
 		credentials: 'include',
 		headers:     {
 			'X-WP-Nonce':   HM.Workflows.Nonce,

--- a/admin/src/Notifications/index.js
+++ b/admin/src/Notifications/index.js
@@ -135,7 +135,7 @@ class Notifications extends React.Component {
 const notificationsWithFetch = withFetch(
 	`${HM.Workflows.Namespace}/notifications/${HM.Workflows.User}`,
 	{
-		expires:     60000,
+		expires:     60 * 1000,
 		credentials: 'include',
 		headers:     {
 			'X-WP-Nonce':   HM.Workflows.Nonce,

--- a/admin/src/withFetch.js
+++ b/admin/src/withFetch.js
@@ -6,8 +6,8 @@ import sh from 'shorthash';
  * Fetch HoC using localStorage.
  */
 const withFetch = ( url, options = {}, name = null ) => {
-	// Store key.
-	const key = `${url}:${sh.unique(JSON.stringify(options))}`;
+	// Store key without expiration.
+	const key = `${url}:${sh.unique(JSON.stringify({ ...options, expires: 0}))}`;
 	// HoC.
 	return Component => {
 		class fetchComponent extends React.Component {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.13
+ * Version: 0.3.14
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Changes the poll timeout to 60s rather than 10s! Removes expiry from the cache key in `withFetch` to prevent localStorage item explosion.


- [ ] Updated changelog
- [ ] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change