### PR TITLE
Add permission checks to editorial comments endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.3.15
+- Bug: Add permissions check to REST controller for editorial comments.
+- Bug: Remove ability for query for editorial comments on all posts.
+
 v0.3.14
 - Bug: Fix cache key in `withFetch` component
 - Enhancement: Reduce polling time for admin notifications

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -56,6 +56,35 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	}
 
 	/**
+	 * Only allow reading editorial comments if the user can edit all the posts being queried.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return bool
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_ids = $request->get_param( 'post' );
+		return array_reduce(
+			$post_ids,
+			function ( $can_edit, $post_id ) {
+				return $can_edit && current_user_can( 'edit_post', $post_id );
+			},
+			true
+		);
+	}
+
+	/**
+	 * Users who can edit a post should be able to view single editorial
+	 * comments on that post.
+	 *
+	 * @param WP_REST_Request $request Current request.
+	 * @return bool
+	 */
+	public function get_item_permissions_check( $request ) {
+		$comment = $this->get_comment( $request['id'] );
+		return current_user_can( 'edit_post', $comment->comment_post_ID );
+	}
+
+	/**
 	 * Allow creating editorial comments.
 	 *
 	 * @param WP_REST_Request $request

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -27,7 +27,7 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	 * Make the post ID or IDs required.
 	 *
 	 * (It's theoretically possible to query for all editorial comments on any
-	 * opst, but the generated query is extremely inefficient as there isn't
+	 * post, but the generated query is extremely inefficient as there isn't
 	 * an index available to use, so it's better to just disallow by default.)
 	 *
 	 * @return [] Comments collection parameters.

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -24,6 +24,23 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	}
 
 	/**
+	 * Make the post ID or IDs required.
+	 *
+	 * (It's theoretically possible to query for all editorial comments on any
+	 * opst, but the generated query is extremely inefficient as there isn't
+	 * an index available to use, so it's better to just disallow by default.)
+	 *
+	 * @return [] Comments collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['post']['required'] = true;
+
+		return $query_params;
+	}
+
+	/**
 	 * Ensure only workflow comments are returned.
 	 *
 	 * @param WP_REST_Request $request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.14
+ * Version: 0.3.15
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Makes two changes to the REST controller for Workflow comments to better align permissions and capabilities with the expected model:

- Prevents users without the capability of editing a post from reading editorial comments on the post
- Limits the /workflows/v1/comments endpoint so that the "post" parameter is required, because querying for comments across all posts is a slow database query.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
