### PR TITLE
Fix permissions for REST comments collection endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Changelog
 =========
 
+v0.3.16
+- Bug: Remove ability for query for editorial comments on all posts.
+
 v0.3.15
 - Bug: Add permissions check to REST controller for editorial comments.
-- Bug: Remove ability for query for editorial comments on all posts.
 
 v0.3.14
 - Bug: Fix cache key in `withFetch` component

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -63,6 +63,11 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		$post_ids = $request->get_param( 'post' );
+
+		if ( empty( $post_ids ) ) {
+			return false;
+		}
+
 		return array_reduce(
 			$post_ids,
 			function ( $can_edit, $post_id ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.15
+ * Version: 0.3.16
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Fixes a logic bug from #148 that bypassed the endpoint permissions check if no post IDs were sent with the request.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
