### PR TITLE
Load stored workflows on init hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+v0.4.0
+- Enhancement: Load stored workflows on init hook.
+
 v0.3.17
 - Enhancement: Add assignee column to post lists.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -33,6 +33,6 @@ add_action( 'plugins_loaded', function () {
 }, 9 );
 
 // Run a consistent hook to load all the stored Workflows.
-add_action( 'plugins_loaded', function () {
+add_action( 'init', function () {
 	do_action( 'hm.workflows.init' );
 }, 20 );

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.3.17
+ * Version: 0.4.0
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Loading stored workflows makes it much easier to register events for custom post types, use REST API for field data, etc.

See  #158.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
