### PR TITLE
Ensure post type is checked before publish event

### DIFF
--- a/lib/events/transition-post-status.php
+++ b/lib/events/transition-post-status.php
@@ -93,6 +93,10 @@ Event::register( 'publish_post' )
 				return null;
 			}
 
+			if ( $post->post_type !== 'post' ) {
+				return null;
+			}
+
 			if ( $new_status !== 'publish' ) {
 				return null;
 			}
@@ -120,6 +124,10 @@ Event::register( 'publish_page' )
 		'action'        => 'transition_post_status',
 		'callback'      => function ( $new_status, $old_status, \WP_Post $post ) {
 			if ( $new_status === $old_status ) {
+				return null;
+			}
+
+			if ( $post->post_type !== 'page' ) {
 				return null;
 			}
 


### PR DESCRIPTION
The built publish events cause 2 emails to be sent as both the `publish_page` and `publish_post` action hooks fire when publishing any post.


- [ ] Updated changelog
- [ ] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change