### PR TITLE
Fix issue 189. Fatal Error when submitting editorial comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changelog
 =========
-v0.4.2
+v0.4.4
 - Bug: Fix fatal error when processing a single editorial comment.
 
 v0.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+v0.4.2
+- Bug: Fix fatal error when processing a single editorial comment.
+
 v0.4.3
 - Bug: With PHP 8.0 enabled, `call_user_func_array()` behaves differently if the parameters array is an associative array.
 

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -62,7 +62,7 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	 * @return bool
 	 */
 	public function get_items_permissions_check( $request ) {
-		$post_ids = $request->get_param( 'post' );
+		$post_ids = (array) $request->get_param( 'post' );
 
 		if ( empty( $post_ids ) ) {
 			return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.4.3
+ * Version: 0.4.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Fixes: https://github.com/humanmade/Workflows/issues/189

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
