### PR TITLE
Fatal Error when submitting editorial comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 v0.4.4
-- Bug: Adding an editorial comment creates a fatal error. A single post ID is used during `get_items_permissions_check` rather than an array and the use of `array_reduce` was causing a fatal error.
+- Bug: Adding an editorial comment creates a fatal error. Bug fix for `get_items_permissions_check` usage of a single post ID or an array of post ID's.
 
 v0.4.3
 - Bug: With PHP 8.0 enabled, `call_user_func_array()` behaves differently if the parameters array is an associative array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+v0.4.4
+- Bug: Adding an editorial comment creates a fatal error. A single post ID is used during `get_items_permissions_check` rather than an array and the use of `array_reduce` was causing a fatal error.
+
 v0.4.3
 - Bug: With PHP 8.0 enabled, `call_user_func_array()` behaves differently if the parameters array is an associative array.
 

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -68,7 +68,7 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 			return false;
 		}
 
-		// Check if $post_ids is an array to handle a single post id.
+		// Check if $post_ids is not an array then return true if the user can edit the post.
 		if ( ! is_array( $post_ids ) ) {
 			return current_user_can( 'edit_post', $post_ids );
 		}

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -62,19 +62,13 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	 * @return bool
 	 */
 	public function get_items_permissions_check( $request ) {
-		$post_ids = $request->get_param( 'post' );
+		$post_id = $request->get_param( 'post' );
 
-		if ( empty( $post_ids ) ) {
+		if ( empty( $post_id ) ) {
 			return false;
 		}
 
-		return array_reduce(
-			$post_ids,
-			function ( $can_edit, $post_id ) {
-				return $can_edit && current_user_can( 'edit_post', $post_id );
-			},
-			true
-		);
+		return current_user_can( 'edit_post', $post_id );
 	}
 
 	/**

--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -62,13 +62,24 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	 * @return bool
 	 */
 	public function get_items_permissions_check( $request ) {
-		$post_id = $request->get_param( 'post' );
+		$post_ids = $request->get_param( 'post' );
 
-		if ( empty( $post_id ) ) {
+		if ( empty( $post_ids ) ) {
 			return false;
 		}
 
-		return current_user_can( 'edit_post', $post_id );
+		// Check if $post_ids is an array to handle a single post id.
+		if ( ! is_array( $post_ids ) ) {
+			return current_user_can( 'edit_post', $post_ids );
+		}
+
+		return array_reduce(
+			$post_ids,
+			function ( $can_edit, $post_id ) {
+				return $can_edit && current_user_can( 'edit_post', $post_id );
+			},
+			true
+		);
 	}
 
 	/**

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.4.3
+ * Version: 0.4.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Related issue - #189 

#### The issue
When submitting a new editorial comment, there is a fatal error being thrown.
> PHP Fatal error:  Uncaught TypeError: array_reduce(): Argument #1 ($array) must be of type array, int given in /usr/src/app/vendor/humanmade/workflows/inc/class-rest-workflow-comments-controller.php:76

The related function `get_items_permissions_check` was only handling the request for multiple post ID's as an array and triggering a fatal error when receiving a single post ID.

#### The Fix
When handling the `$post_ids` during the permission check, if `$post_ids` is **not** an array then do an early return with a permission check.

#### Acceptance Criteria
- [x] Post an editorial comment without an error occurring.
- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change