### PR TITLE
Exclude editorial comments in post comment count.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+v0.4.5
+- Bug: Exclude editorial comments from post comment count.
+
 v0.4.4
 - Bug: Fix fatal error when processing a single editorial comment.
 

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -183,7 +183,6 @@ add_action( 'pre_get_comments', __NAMESPACE__ . '\comments_query' );
  * @return int
  */
 function exclude_workflow_comments_from_count( $count, $post_id ) {
-
 	if ( intval( $count ) === 0 ) {
 		return $count;
 	}

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -176,6 +176,28 @@ function comments_query( WP_Comment_Query $query ) {
 add_action( 'pre_get_comments', __NAMESPACE__ . '\comments_query' );
 
 /**
+ * Filter the comment count to exclude workflow comments.
+ *
+ * @param int $count
+ * @param int $post_id
+ * @return int
+ */
+function exclude_workflow_comments_from_count( $count, $post_id ) {
+	if ( $count == 0 ) {
+		return $count;
+	}
+
+	$args = [
+		'post_id' => $post_id,
+		'type__not_in' => [ 'workflow' ],
+	];
+	$comments = get_comments( $args );
+	return count( $comments );
+}
+
+add_filter( 'get_comments_number', __NAMESPACE__ . '\\exclude_workflow_comments_from_count', 10, 2 );
+
+/**
  * Register assignees meta.
  */
 function assignees_api() {

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -189,10 +189,10 @@ function exclude_workflow_comments_from_count( $count, $post_id ) {
 
 	$args = [
 		'post_id' => $post_id,
-		'type__not_in' => ['workflow'],
+		'type__not_in' => [ 'workflow' ],
+		'count' => true,
 	];
-	$comments = get_comments( $args );
-	return count( $comments );
+	return get_comments( $args );
 }
 
 add_filter( 'get_comments_number', __NAMESPACE__ . '\exclude_workflow_comments_from_count', 10, 2 );

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -178,8 +178,8 @@ add_action( 'pre_get_comments', __NAMESPACE__ . '\comments_query' );
 /**
  * Filter the comment count to exclude workflow comments.
  *
- * @param int $count
- * @param int $post_id
+ * @param int $count The current number of comments found.
+ * @param int $post_id The post ID to return the number of comments for.
  * @return int
  */
 function exclude_workflow_comments_from_count( $count, $post_id ) {

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -183,7 +183,8 @@ add_action( 'pre_get_comments', __NAMESPACE__ . '\comments_query' );
  * @return int
  */
 function exclude_workflow_comments_from_count( $count, $post_id ) {
-	if ( $count == 0 ) {
+
+	if ( intval( $count ) === 0 ) {
 		return $count;
 	}
 

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -195,7 +195,7 @@ function exclude_workflow_comments_from_count( $count, $post_id ) {
 	return count( $comments );
 }
 
-add_filter( 'get_comments_number', __NAMESPACE__ . '\\exclude_workflow_comments_from_count', 10, 2 );
+add_filter( 'get_comments_number', __NAMESPACE__ . '\exclude_workflow_comments_from_count', 10, 2 );
 
 /**
  * Register assignees meta.

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -189,7 +189,7 @@ function exclude_workflow_comments_from_count( $count, $post_id ) {
 
 	$args = [
 		'post_id' => $post_id,
-		'type__not_in' => [ 'workflow' ],
+		'type__not_in' => ['workflow'],
 	];
 	$comments = get_comments( $args );
 	return count( $comments );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.4.4
+ * Version: 0.4.5
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
Related Issue : https://github.com/humanmade/Workflows/issues/194

Currently the comment count is displayed as a combined total of comments and editorial comments. This PR excludes "workflow" comments from the post comment count, giving a true number of comments per post.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
