### PR TITLE
Subtract workflow count from comment count instead of overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+v0.4.6
+- Bug: Do not discard previous filter value when excluding editorial comments from post comment count.
+
 v0.4.5
 - Bug: Exclude editorial comments from post comment count.
 

--- a/lib/events/new-editorial-comment.php
+++ b/lib/events/new-editorial-comment.php
@@ -187,12 +187,13 @@ function exclude_workflow_comments_from_count( $count, $post_id ) {
 		return $count;
 	}
 
-	$args = [
+	$workflow_comment_count = get_comments( [
 		'post_id' => $post_id,
-		'type__not_in' => [ 'workflow' ],
+		'type__in' => [ 'workflow' ],
 		'count' => true,
-	];
-	return get_comments( $args );
+	] );
+
+	return $count - $workflow_comment_count;
 }
 
 add_filter( 'get_comments_number', __NAMESPACE__ . '\exclude_workflow_comments_from_count', 10, 2 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-workflows",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": "https://github.com/humanmade/Workflows",
   "scripts": {
     "start": "cd admin && npm run start",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Workflows
  * Plugin URI: https://github.com/humanmade/Workflows
  * Description: A flexible workflows framework for WordPress
- * Version: 0.4.5
+ * Version: 0.4.6
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
  * Text Domain: hm-workflows


### PR DESCRIPTION
**Note**: I have tested that this fixes the bug described below, but I have _not_ tested that it still correctly handles workflow comments. Whatever testing was done to validate #195 should be repeated for this PR, I did not see any PHP unit tests I could update. (And unfortunately I don't have time to add them.)

---------

In 0.4.5, after #195 was merged, a bug was introduced in an Altis client's application. If an application previously filtered `get_comments_number` (for example, to not count author replies when showing a comment count), that filtering would be undone by the filter in this module.

Example: if you had this code in an Altis application using Bylines,

```php
function get_author_reply_count( int $post_id ) : int {
	$byline_users = Bylines\get_all_byline_authors( $post_id );

	$comment_args = [
		'count'          => true,
		'post_id'        => $post_id,
		'status'         => 'approve',
		'author__in'     => $byline_users,
	];

	return get_comments( $comment_args );
}
add_filter( 'get_comments_number', 'filter_get_comments_number', 10, 2 );
```
on a post with 4 comments, 3 of them from the author, then after priority 10 the filter value would be 1. But when the filter introduced in #195 fires at priority 11, the value would be incorrectly reset back to 4, since the new get_comments query from workflows ignores the prior value passed in to the filter.

- [x] Updated changelog
- [x] Updated version number in `package.json` and `plugin.php` file with appropriate MAJOR.MINOR.PATCH change
