### PR TITLE
Use html_entity_decode not wp_specialchars_decode

### DIFF
--- a/lib/destinations/email.php
+++ b/lib/destinations/email.php
@@ -71,7 +71,7 @@ function email_handler( array $recipients, array $message, array $data = [] ) {
 	if ( isset( $data['group_email'] ) ) {
 		wp_mail(
 			$emails,
-			wp_specialchars_decode( $message['subject'] ),
+			html_entity_decode( $message['subject'] ),
 			$message['text'],
 			$headers
 		);
@@ -79,7 +79,7 @@ function email_handler( array $recipients, array $message, array $data = [] ) {
 		foreach ( $emails as $email ) {
 			wp_mail(
 				$email,
-				wp_specialchars_decode( $message['subject'] ),
+				html_entity_decode( $message['subject'] ),
 				$message['text'],
 				$headers
 			);


### PR DESCRIPTION
#177 reported a bug that email subjects contained encoded characters which did not display correctly in some email clients. 

The suggested fix was to use [`wp_specialchars_decode`](https://developer.wordpress.org/reference/functions/wp_specialchars_decode/) and this was added in #178. 

However... one case specifically mentioned in the original bug was "em-dash". And this is not fixed!

Why is this and why is it important? Well `wptexturise` converts the `-` character to an em-dash encoded as `&#8211;`, and this does not get decoded by wp_specialchars_decode! (There is a comment on the developer docs flagging this). 

So what is the solution? Probably we can just use `html_entity_decode` instead. 