### PR TITLE
Fix #161 user select in workflows removed selected values

### DIFF
--- a/admin/src/WorkflowUI.js
+++ b/admin/src/WorkflowUI.js
@@ -570,7 +570,11 @@ class WorkflowUI extends Component {
 									.then( response => response.json() )
 									.then( data => ({ options: data }) )
 								}
-								value={(recipient.users || []).filter(user => recipient.value.includes(String(user.id)))}
+								value={
+									recipient.multi
+										? ( recipient.users || [] ).filter( user => recipient.value.includes( String( user.id ) ) )
+										: recipient.users
+								}
 								labelKey={recipient.endpoint.labelKey || 'name'}
 								valueKey={recipient.endpoint.valueKey || 'id'}
 								onChange={option => this.setState( {
@@ -579,24 +583,27 @@ class WorkflowUI extends Component {
 											return rec;
 										}
 
-										const selectedValue = rec.multi
-											? option.map(opt => String(opt[recipient.endpoint.valueKey || 'id']))
-											: String(option[recipient.endpoint.valueKey || 'id']);
+										// Make sure to only set value if option is not null or empty.
+										const selectedValue = option ?
+											rec.multi
+												? option.map(opt => String(opt[recipient.endpoint.valueKey || 'id']))
+												: String( option[recipient.endpoint.valueKey || 'id'] )
+											: '';
 
 										// Handle single or multi-select options
 										const selectedUsers = rec.multi ? option : [option];
 
 										// Merge with the existing users
-										const mergedItems = [...(rec.users || []), ...(selectedUsers || [])].reduce((acc, current) => {
-											if (!acc.some(item => item.id === current.id)) {
-												acc.push(current);
+										const mergedItems = [...(rec.users || []), ...( selectedUsers || [])].reduce( ( acc, current ) => {
+											if ( ! acc.some(item => item.id === current.id ) ) {
+												acc.push( current );
 											}
 											return acc;
-										}, []);
+										}, [] );
 
 										return Object.assign({}, rec, {
 											value: selectedValue,
-											users: mergedItems
+											users: rec.multi ? mergedItems : mergedItems[0]
 										});
 									})
 								})}

--- a/admin/src/WorkflowUI.js
+++ b/admin/src/WorkflowUI.js
@@ -294,7 +294,7 @@ class WorkflowUI extends Component {
 							: {};
 						let recipientUsers = {};
 
-						if (recipient.users) {
+						if ( recipient.users && recipient.users.length > 0 ) {
 							recipientUsers = { users: recipientObject.multi ? recipient.users : recipient.users[0] };
 						}
 

--- a/inc/class-rest-workflows-controller.php
+++ b/inc/class-rest-workflows-controller.php
@@ -93,12 +93,12 @@ class REST_Workflows_Controller extends WP_REST_Posts_Controller {
 						$user_ids = isset( $recipient['value'] ) ? $recipient['value'] : [];
 
 						if ( ! empty( $user_ids ) && is_array( $user_ids ) ) {
-							$users = get_users([
-								'include' => $user_ids
-							]);
+							$users = get_users( [
+								'include' => $user_ids,
+							] );
 
 							// Prepare the formatted response to include only 'id' and 'name'
-							$recipient['users'] = array_map( function( $user ) {
+							$recipient['users'] = array_map( function ( $user ) {
 								return [
 									'id'   => $user->ID,
 									'name' => $user->display_name,


### PR DESCRIPTION
To fix issue #161 

### Steps to Reproduce:

1. Add a new workflow.
2. Under "When should the workflow run?" dropdown, select any value.
3. Fill in any subject and message under "What message should be sent?"
4. Set "Specific users..." under "Who should be notified?"
5. In the user selection dropdown, choose a user.
6. Start typing to search for a user. If the dropdown list updates and does not include the previously selected user, that user will disappear from the field.
7. The user will reappear only if the dropdown list again contains the previously selected user.

For more details, watch this video: https://share.cleanshot.com/97dbyHry

---

### Fixes:

1. **Backend (PHP):**
   - The backend now checks if the recipient type is 'user'. If so, it loops through the selected values and returns an array of users with `id` and `name` fields, ensuring previously selected users are preserved in the dropdown.

2. **Frontend (React):**
   - The frontend now initializes the `recipient.users` array with the data coming from PHP for the selected values.
   - The dropdown is always in sync with the latest selected users by using this array.
   - The `onChange` event now appends newly selected users to `recipient.users`, ensuring the list remains up to date and users do not disappear during searches.
