### PR TITLE
Do not load workflows scripts on site frontend

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -42,7 +42,7 @@ function enqueue_ui_assets() {
 		return;
 	}
 
-	if ( ! is_admin() && ! is_admin_bar_showing() ) {
+	if ( ! is_admin() ) {
 		return;
 	}
 


### PR DESCRIPTION
This may break a core assumption of the plugin, but on Altis sites with a substantial proportion of logged-in traffic, the workflows notification API calls add up to a substantial number of GET requests.

This PR proposes to disable enqueuing the Workflows scripts in all non-admin contexts, not just when the admin bar is not shown. I'm opening it to start a discussion about what behaviors this may break, and see if we can avoid performance and scaling impacts from this plugin.
