### PR TITLE
Fix fatal in PHP 8.2 accessing comment as array

### DIFF
--- a/inc/class-rest-workflow-comments-controller.php
+++ b/inc/class-rest-workflow-comments-controller.php
@@ -315,7 +315,11 @@ class REST_Workflow_Comments_Controller extends WP_REST_Comments_Controller {
 	protected function get_comment( $id ) {
 		$result = parent::get_comment( $id );
 
-		if ( isset( $result['type'] ) && $result['type'] !== 'workflow' ) {
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( isset( $result->comment_type ) && $result->comment_type !== 'workflow' ) {
 			return new WP_Error( 'rest_post_invalid_type', __( 'Invalid comment type.', 'hm-workflows' ), array( 'status' => 400 ) );
 		}
 


### PR DESCRIPTION
Need to use WP_Comment object rather than accessing it as an array now.